### PR TITLE
Details/Activity tabs, various other functionality

### DIFF
--- a/packages/services/src/api-services/api-services.ts
+++ b/packages/services/src/api-services/api-services.ts
@@ -1,4 +1,4 @@
-import {Api} from "@apicurio/models";
+import {Api, ApiCollaborator} from "@apicurio/models";
 import {AbstractHubService} from "./hub";
 import {ConfigService} from "../config/config.service";
 import {IAuthenticationService} from "../authentication/auth.service";
@@ -10,6 +10,7 @@ import { AxiosRequestConfig } from "axios";
  */
 export class ApisService extends AbstractHubService {
     private cachedApis: Api[] = null;
+    private cachedCollaborators: ApiCollaborator[] = null;
 
     /**
      * Constructor.
@@ -20,6 +21,25 @@ export class ApisService extends AbstractHubService {
         super(authService, config);
     }
 
+              /**
+     * @see ApisService.getCollaborators
+     */
+    public getCollaborators(apiId: string): Promise<ApiCollaborator[]> {
+      console.info("[ApisService] Getting collaborators for API Design %s", apiId);
+
+      let getCollaboratorsUrl: string = this.endpoint("/designs/:designId/collaborators", {
+          designId: apiId
+      });
+      let options: any = this.options({ "Accept": "application/json" });
+
+      console.info("[ApisService] Fetching collaborator list: %s", getCollaboratorsUrl);
+      return this.httpGet<ApiCollaborator[]>(getCollaboratorsUrl, options, (resp) => {
+        this.cachedCollaborators = resp as ApiCollaborator[];
+        console.log(`api-services: cachedCollaborators = ${this.cachedCollaborators}`);
+        return this.cachedCollaborators;
+      });
+  }
+
     // Gets all APIs
     public getApis(): Promise<Api[]> {
       console.info("[ApisService] Getting all APIs");
@@ -29,7 +49,8 @@ export class ApisService extends AbstractHubService {
   
       console.info("[ApisService] Fetching API list: %s", listApisUrl);
       return this.httpGet<Api[]>(listApisUrl, options, (resp) => {
-        this.cachedApis = resp.data as Api[];
+        this.cachedApis = resp as Api[];
+        // this.getCollaborators(this.cachedApis[0].id).then( (value: ApiCollaborator[]) => {debugger;});
         return this.cachedApis;
       })
     }

--- a/packages/services/src/api-services/current-user-services.ts
+++ b/packages/services/src/api-services/current-user-services.ts
@@ -36,7 +36,7 @@ export class CurrentUserService extends AbstractHubService {
 
         console.info("[CurrentUserService] Fetching user activity: %s", activityUrl);
         return this.httpGet<ApiDesignChange[]>(activityUrl, options, (resp) => {
-            return resp.data as ApiDesignChange[];
+            return resp as ApiDesignChange[];
         });
     }
 }

--- a/packages/services/src/api-services/hub.ts
+++ b/packages/services/src/api-services/hub.ts
@@ -108,10 +108,10 @@ export abstract class AbstractHubService {
     return axios.request(config)
     .then(response => {
       if (successCallback) {
-       return successCallback(response);
+       return successCallback(response.data);
       }
       else {
-        return response;
+        return response.data;
      }
     })
     .catch(error => console.log(error)); // handle error state

--- a/packages/studio/src/app/appHeader.tsx
+++ b/packages/studio/src/app/appHeader.tsx
@@ -28,7 +28,6 @@ export const AppHeader = () => {
   const setNotificationDrawerState = (notificationDrawerState: boolean) => {
     globalContext.setNotificationDrawerExpanded(!notificationDrawerState);
   }
-
   
     const [isKebabDropdownOpen, setKebabDropdown] = useState(false);
     const [isKebabDropdownMdOpen, setKebabDropdownMd] = useState(false);

--- a/packages/studio/src/app/common/appConfig.ts
+++ b/packages/studio/src/app/common/appConfig.ts
@@ -13,7 +13,7 @@ export class Services {
 
     private static singleton: Services;
     public configService: ConfigService = new ConfigService();
-    public autheticationService : KeycloakAuthenticationService = new KeycloakAuthenticationService(this.configService);
-    public apisService: ApisService = new ApisService(this.autheticationService, this.configService);
-    public currentUserService: CurrentUserService = new CurrentUserService(this.autheticationService, this.configService);
+    public authenticationService : KeycloakAuthenticationService = new KeycloakAuthenticationService(this.configService);
+    public apisService: ApisService = new ApisService(this.authenticationService, this.configService);
+    public currentUserService: CurrentUserService = new CurrentUserService(this.authenticationService, this.configService);
 }

--- a/packages/studio/src/app/components/api/apiActivityView/apiActivityView.tsx
+++ b/packages/studio/src/app/components/api/apiActivityView/apiActivityView.tsx
@@ -3,15 +3,38 @@ import { DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCel
 import { ApiActivityItem } from '../apiActivityItem/apiActivityItem';
 import { GlobalContext } from '../../../../context';
 
-export const ApiActivityView = () => {
+export interface ApiActivityViewProps {
+    currentApi: any
+  }
+
+function findId(apis: any[], id: string) {
+  console.log(`array is ${JSON.stringify(apis)}, id is ${id}`);
+    const apiTemp = apis.find(api => api.apiId === id);
+    if (apiTemp !== undefined) {
+      return apiTemp;
+    }
+    else {
+      return Error;
+    }
+  }
+
+export const ApiActivityView = (props) => {
   const { recentActivity } = { ... React.useContext(GlobalContext).store };
+  const selectedApi = props.currentApi.id;
+  let specificApiActivity = [];
+
+  specificApiActivity = findId(recentActivity, selectedApi);
+
+  const noActivityMsg = "No activity found for this API.";
+
+
     return (
       <React.Fragment>
       <div className="api-details-content">
           <h3>Activity</h3>
+                       { specificApiActivity !== Error ? recentActivity.map((activity, index) =>
                    <DataList aria-label="app-data-list-api-activity" key="api-activity-list">
                    <React.Fragment>
-                       { recentActivity.map((activity, index) =>
                           <DataListItem aria-labelledby={`data-list-item-${index}`} key={index}>
                               <DataListItemRow>
                               <DataListItemCells
@@ -24,13 +47,13 @@ export const ApiActivityView = () => {
                                               activityData={activity.data}
                                           />
                                       </DataListCell>
-                                  ]}
-                                  />
+                                  ]}/>
                               </DataListItemRow>
                           </DataListItem>
-                      )}
-                  </React.Fragment>
-              </DataList>
+                          </React.Fragment>
+                      </DataList>
+                      ) :
+                      <p>{noActivityMsg}</p>}
       </div>
       </React.Fragment>
     )

--- a/packages/studio/src/app/components/api/apiActivityView/apiActivityView.tsx
+++ b/packages/studio/src/app/components/api/apiActivityView/apiActivityView.tsx
@@ -1,51 +1,39 @@
 import React from 'react';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCell } from '@patternfly/react-core';
+import { ApiActivityItem } from '../apiActivityItem/apiActivityItem';
+import { GlobalContext } from '../../../../context';
 
-export class ApiActivityView extends React.Component {
-
-  // private detailsContentRef = React.createRef();
-  // private activityContentRef = React.createRef();
-  constructor(props) {
-    super(props);
-    // this.state = {
-    //   activeTabKey: 0
-    };
-  
-  render() {
-    // const { createdOn, createdBy} = this.props;
+export const ApiActivityView = () => {
+  const { recentActivity } = { ... React.useContext(GlobalContext).store };
     return (
-    //   <React.Fragment>
-    //     <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-    //       <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}/>
-    //       <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
-    //     </Tabs>
-    //     <div>
-    //       <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
-    //       <Grid>
-    //               <GridItem sm={12} md={12}>
-    //                 <ApiDetailsView></ApiDetailsView>
-    //                 </GridItem>
-    //                 </Grid>
-
-    <div>
-        Activity
-            {/* {createdOn}
-            {createdBy} */}
-    </div>
-
-        //   </TabContent>
-        //   <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
-        //     Activity
-        //   </TabContent>
-    //   </React.Fragment>
-    );
-  }
-
-//   private handleTabClick = (event: React.MouseEvent, tabIndex: any) => {
-//     this.setState({
-//       activeTabKey: tabIndex
-//     });
-//   };
+      <React.Fragment>
+      <div className="api-details-content">
+          <h3>Activity</h3>
+                   <DataList aria-label="app-data-list-api-activity" key="api-activity-list">
+                   <React.Fragment>
+                       { recentActivity.map((activity, index) =>
+                          <DataListItem aria-labelledby={`data-list-item-${index}`} key={index}>
+                              <DataListItemRow>
+                              <DataListItemCells
+                                  dataListCells={[
+                                      <DataListCell key="1">
+                                          <ApiActivityItem
+                                              activityApiName={activity.apiName}
+                                              activityType={activity.type}
+                                              activityOn={activity.on}
+                                              activityData={activity.data}
+                                          />
+                                      </DataListCell>
+                                  ]}
+                                  />
+                              </DataListItemRow>
+                          </DataListItem>
+                      )}
+                  </React.Fragment>
+              </DataList>
+      </div>
+      </React.Fragment>
+    )
 }
 
 export default ApiActivityView;

--- a/packages/studio/src/app/components/api/apiActivityView/apiActivityView.tsx
+++ b/packages/studio/src/app/components/api/apiActivityView/apiActivityView.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+
+export class ApiActivityView extends React.Component {
+
+  // private detailsContentRef = React.createRef();
+  // private activityContentRef = React.createRef();
+  constructor(props) {
+    super(props);
+    // this.state = {
+    //   activeTabKey: 0
+    };
+  
+  render() {
+    // const { createdOn, createdBy} = this.props;
+    return (
+    //   <React.Fragment>
+    //     <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+    //       <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}/>
+    //       <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
+    //     </Tabs>
+    //     <div>
+    //       <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
+    //       <Grid>
+    //               <GridItem sm={12} md={12}>
+    //                 <ApiDetailsView></ApiDetailsView>
+    //                 </GridItem>
+    //                 </Grid>
+
+    <div>
+        Activity
+            {/* {createdOn}
+            {createdBy} */}
+    </div>
+
+        //   </TabContent>
+        //   <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
+        //     Activity
+        //   </TabContent>
+    //   </React.Fragment>
+    );
+  }
+
+//   private handleTabClick = (event: React.MouseEvent, tabIndex: any) => {
+//     this.setState({
+//       activeTabKey: tabIndex
+//     });
+//   };
+}
+
+export default ApiActivityView;

--- a/packages/studio/src/app/components/api/apiActivityView/index.ts
+++ b/packages/studio/src/app/components/api/apiActivityView/index.ts
@@ -1,0 +1,1 @@
+export * from './apiActivityView';

--- a/packages/studio/src/app/components/api/apiCard/apiCardView.tsx
+++ b/packages/studio/src/app/components/api/apiCard/apiCardView.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Gallery } from '@patternfly/react-core';
 import {ApiCard} from './apiCard';
-import data from '../../../../api-data.json';
+import { GlobalContext } from '../../../../context';
 
 export const ApiCardView: React.FunctionComponent<any> = (props) => {
-  const apiData = data.apis;
-  const cardList = apiData.map((api, index) =>
+  const { apis } = {... useContext(GlobalContext).store}
+
+  const cardList = apis.map((api, index) =>
     <ApiCard
       key={index}
       id={api.id}

--- a/packages/studio/src/app/components/api/apiDataList/apiDataList.tsx
+++ b/packages/studio/src/app/components/api/apiDataList/apiDataList.tsx
@@ -33,7 +33,7 @@ class ApiDataList extends React.Component<ApiDataListProps, ApiDataListState> {
         selectedDataListItemId={this.state.selectedDataListItemId}
         onSelectDataListItem={this.onSelectDataListItem}
       >
-        <ApiDataListItem/>
+        <ApiDataListItem />
       </DataList>
     );
   }

--- a/packages/studio/src/app/components/api/apiDataList/apiDataList.tsx
+++ b/packages/studio/src/app/components/api/apiDataList/apiDataList.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import {DataList} from '@patternfly/react-core';
 import ApiDataListItem from './apiDataListItem';
 
-interface AppDataListProps {
+interface ApiDataListProps {
   viewDetails: React.MouseEventHandler,
   selectItem: FunctionStringCallback,
   keyListItem: FunctionStringCallback
 }
 
-interface AppDataListState {
+interface ApiDataListState {
   selectedDataListItemId: string
 }
 
-class AppDataList extends React.Component<AppDataListProps, AppDataListState> {
-  constructor(props: AppDataListProps) {
+class ApiDataList extends React.Component<ApiDataListProps, ApiDataListState> {
+  constructor(props: ApiDataListProps) {
     super(props);
     this.state = {
       selectedDataListItemId: ''
@@ -39,4 +39,4 @@ class AppDataList extends React.Component<AppDataListProps, AppDataListState> {
   }
 }
 
-export default AppDataList;
+export default ApiDataList;

--- a/packages/studio/src/app/components/api/apiDataList/apiDataListItem.tsx
+++ b/packages/studio/src/app/components/api/apiDataList/apiDataListItem.tsx
@@ -1,29 +1,16 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 import { Button, DataListItem, DataListItemCells, DataListItemRow, DataListCell, DataListCheck, DataListAction } from '@patternfly/react-core';
 import {ApiTag} from '../apiTag';
 import {ApiDropdownKebab} from '../apiDropDownKebab';
 import ApicurioIcon from '../../../assets/apicurio-icon.png';
 import './apiDataListItem.css';
 import { GlobalContext, GlobalContextObj } from '../../../../context';
-import ApiDrawerPanelContentProps from '../apiDrawer/apiDrawerPanelContent'
-
-// export interface ApiDataListItemProps {
-//   currentApiId: string,
-//   apiDrawerExpanded: boolean
-// }
-// interface ApiDataListItemState {
-//   apiDrawerExpanded: boolean,
-// }
 
 export const ApiDataListItem = () => {
-  // console.log(`apiDataListItem props is: ${JSON.stringify(props)}`);
-
   const { apis } = {... useContext(GlobalContext).store}
   const globalContext: GlobalContextObj = useContext(GlobalContext);
-
-  const setApiDrawerState = (apiDrawerState: boolean) => {
+  const setApiDrawerState = (apiDrawerState: boolean, currentApiId: string) => {
     globalContext.setApiDrawerExpanded(!apiDrawerState);
-    console.log(`apiDataListItem: apiDrawerState is ${apiDrawerState}`);
   }
 
     return (

--- a/packages/studio/src/app/components/api/apiDataList/apiDataListItem.tsx
+++ b/packages/studio/src/app/components/api/apiDataList/apiDataListItem.tsx
@@ -4,11 +4,27 @@ import {ApiTag} from '../apiTag';
 import {ApiDropdownKebab} from '../apiDropDownKebab';
 import ApicurioIcon from '../../../assets/apicurio-icon.png';
 import './apiDataListItem.css';
-import { GlobalContext } from '../../../../context';
+import { GlobalContext, GlobalContextObj } from '../../../../context';
+import ApiDrawerPanelContentProps from '../apiDrawer/apiDrawerPanelContent'
+
+// export interface ApiDataListItemProps {
+//   currentApiId: string,
+//   apiDrawerExpanded: boolean
+// }
+// interface ApiDataListItemState {
+//   apiDrawerExpanded: boolean,
+// }
 
 export const ApiDataListItem = () => {
+  // console.log(`apiDataListItem props is: ${JSON.stringify(props)}`);
 
   const { apis } = {... useContext(GlobalContext).store}
+  const globalContext: GlobalContextObj = useContext(GlobalContext);
+
+  const setApiDrawerState = (apiDrawerState: boolean) => {
+    globalContext.setApiDrawerExpanded(!apiDrawerState);
+    console.log(`apiDataListItem: apiDrawerState is ${apiDrawerState}`);
+  }
 
     return (
       <React.Fragment>
@@ -37,7 +53,7 @@ export const ApiDataListItem = () => {
               ]}
               />
             <DataListAction aria-labelledby={`data-list-item-${api.id}`} id={`data-list-item-${api.id}`} aria-label="Actions">
-                <Button variant="link">View Details</Button>
+                <Button variant="link" onClick={() => setApiDrawerState(globalContext.store.apiDrawerExpanded)}>View Details</Button>
                 <Button variant="secondary">Edit API</Button>
                 <ApiDropdownKebab/>
             </DataListAction>

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.css
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.css
@@ -1,7 +1,21 @@
+div span {
+  padding-bottom: var(--pf-global--spacer--sm);
+  margin-left: 16px;
+}
+div h3 {
+  font-weight: bold;
+  margin-top: var(--pf-global--spacer--md);
+  margin-bottom: var(--pf-global--spacer--sm);
+}
+
 .api-details-content {
     padding-left: var(--pf-global--spacer--md); /* remove this when new drawer styles in pf are added */
   }
-  
+
+  .app-details-content.heading {
+    padding-bottom: var(--pf-global--spacer--sm);
+    margin-left: 16px;
+  }
   .api-details-content-body {
     padding: 0 !important;
   }
@@ -9,3 +23,8 @@
   .api-details-content-body .pf-c-drawer__panel-body {
     padding: 0;
   }
+
+  .app-details-content-icon-text {
+    padding-bottom: var(--pf-global--spacer--sm);
+    margin-left: 16px;
+}

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.css
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.css
@@ -1,0 +1,11 @@
+.api-details-content {
+    padding-left: var(--pf-global--spacer--md); /* remove this when new drawer styles in pf are added */
+  }
+  
+  .api-details-content-body {
+    padding: 0 !important;
+  }
+  
+  .api-details-content-body .pf-c-drawer__panel-body {
+    padding: 0;
+  }

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
@@ -1,51 +1,38 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
+import {GlobalContext, GlobalContextObj, DashboardViews} from '../../../../context';
+import ApiDataListState from '../apiDataList/apiDataListItem';
+import './apiDetailsView.css';
 
-export class ApiDetailsView extends React.Component {
+export const ApiDetailsView: React.FunctionComponent = () => {
 
-  // private detailsContentRef = React.createRef();
-  // private activityContentRef = React.createRef();
-  constructor(props) {
-    super(props);
-    // this.state = {
-    //   activeTabKey: 0
-    };
-  
-  render() {
-    const { createdOn, createdBy} = this.props;
-    return (
-    //   <React.Fragment>
-    //     <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-    //       <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}/>
-    //       <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
-    //     </Tabs>
-    //     <div>
-    //       <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
-    //       <Grid>
-    //               <GridItem sm={12} md={12}>
-    //                 <ApiDetailsView></ApiDetailsView>
-    //                 </GridItem>
-    //                 </Grid>
-
-    <div>
-        Details
-            {createdOn}
-            {createdBy}
-    </div>
-
-        //   </TabContent>
-        //   <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
-        //     Activity
-        //   </TabContent>
-    //   </React.Fragment>
-    );
+  function findId(array: any[], id: string) {
+    const apiTemp = array.find(api => api.id === id);
+    if (apiTemp !== undefined) {
+      return apiTemp;
+    }
+    else {
+      return Error;
+    }
   }
 
-//   private handleTabClick = (event: React.MouseEvent, tabIndex: any) => {
-//     this.setState({
-//       activeTabKey: tabIndex
-//     });
-//   };
-}
+  const currentId = ApiDataListState;
+
+  const { apis } = {... useContext(GlobalContext).store}
+  // const apiObject = findId(apis, props.currentApiId);
+
+  // const globalContext: GlobalContextObj = useContext(GlobalContext);
+  
+    return (
+    <div className="api-details-content">
+        <p><b>Details</b></p>
+        <p>Created on {}</p>
+        <p>Created by {}</p>
+        <p>{} Other collaborators</p>
+        <br />
+        <p><b>Collaborators</b></p>
+    </div>
+    );
+  }
 
 export default ApiDetailsView;

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
@@ -3,22 +3,38 @@ import { UserIcon, UsersIcon, OutlinedClockIcon } from '@patternfly/react-icons'
 import './apiDetailsView.css';
 import moment from "moment";
 
+// export interface ApiDetailsViewProps {
+//   createdBy: string,
+//   createdOn: Date
+// }
+// interface ApiDetailsViewState {
+//   activeTabKey: number
+// }
+
 export interface ApiDetailsViewProps {
-  createdBy: string,
-  createdOn: Date
+  // createdBy: string,
+  // createdOn: Date
+  currentApi: any
 }
-interface ApiDetailsViewState {
-  activeTabKey: number
-}
-export class ApiDetailsView extends React.Component<ApiDetailsViewProps, ApiDetailsViewState> {
-  constructor(props: ApiDetailsViewProps) {
-    super(props);
-    this.state = {
-      activeTabKey: 0
-    };
-  }
-  render() {
-    const { createdOn, createdBy} = this.props;
+export const ApiDetailsView: React.FunctionComponent<ApiDetailsViewProps> = (props) => {
+
+  console.log(`apiDetailsView props is: ${JSON.stringify(props.currentApi)}`);
+  const createdOn = props.currentApi.createdOn;
+  const createdBy = props.currentApi.createdBy;
+
+
+// export class ApiDetailsView extends React.Component<ApiDetailsViewProps, ApiDetailsViewState> {
+//   constructor(props: ApiDetailsViewProps) {
+//     super(props);
+//     this.state = {
+//       activeTabKey: 0
+//     };
+//   }
+
+//   render() {
+//     // const { createdOn, createdBy} = this.props;
+//     console.log(`apiDetailsView props is: ${JSON.stringify(this.props)}`);
+
     return (
       <React.Fragment>
       <div className="api-details-content">
@@ -32,6 +48,6 @@ export class ApiDetailsView extends React.Component<ApiDetailsViewProps, ApiDeta
       </React.Fragment>
       );
   }
-}
 
+// }
 export default ApiDetailsView;

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
@@ -5,7 +5,7 @@ import moment from "moment";
 
 export interface ApiDetailsViewProps {
   createdBy: string,
-  createdOn: Date,
+  createdOn: Date
 }
 interface ApiDetailsViewState {
   activeTabKey: number
@@ -25,7 +25,7 @@ export class ApiDetailsView extends React.Component<ApiDetailsViewProps, ApiDeta
           <h3>Details</h3>
           <p><OutlinedClockIcon /><span>Created on {moment(createdOn).format('MMM DD, YYYY')}</span></p>
           <p><UserIcon /><span>Created by {createdBy}</span></p>
-          <p><UsersIcon /><span>Other collaborators {}</span></p>
+          <p><UsersIcon /><span>? Other collaborators</span></p>
           <br />
           <h3>Collaborators</h3>
       </div>

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+
+export class ApiDetailsView extends React.Component {
+
+  // private detailsContentRef = React.createRef();
+  // private activityContentRef = React.createRef();
+  constructor(props) {
+    super(props);
+    // this.state = {
+    //   activeTabKey: 0
+    };
+  
+  render() {
+    const { createdOn, createdBy} = this.props;
+    return (
+    //   <React.Fragment>
+    //     <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+    //       <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}/>
+    //       <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
+    //     </Tabs>
+    //     <div>
+    //       <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
+    //       <Grid>
+    //               <GridItem sm={12} md={12}>
+    //                 <ApiDetailsView></ApiDetailsView>
+    //                 </GridItem>
+    //                 </Grid>
+
+    <div>
+        Details
+            {createdOn}
+            {createdBy}
+    </div>
+
+        //   </TabContent>
+        //   <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
+        //     Activity
+        //   </TabContent>
+    //   </React.Fragment>
+    );
+  }
+
+//   private handleTabClick = (event: React.MouseEvent, tabIndex: any) => {
+//     this.setState({
+//       activeTabKey: tabIndex
+//     });
+//   };
+}
+
+export default ApiDetailsView;

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
@@ -1,39 +1,15 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { UserIcon, UsersIcon, OutlinedClockIcon } from '@patternfly/react-icons';
 import './apiDetailsView.css';
 import moment from "moment";
 
-// export interface ApiDetailsViewProps {
-//   createdBy: string,
-//   createdOn: Date
-// }
-// interface ApiDetailsViewState {
-//   activeTabKey: number
-// }
-
 export interface ApiDetailsViewProps {
-  // createdBy: string,
-  // createdOn: Date
   currentApi: any
 }
-export const ApiDetailsView: React.FunctionComponent<ApiDetailsViewProps> = (props) => {
 
-  console.log(`apiDetailsView props is: ${JSON.stringify(props.currentApi)}`);
+export const ApiDetailsView: React.FunctionComponent<ApiDetailsViewProps> = (props) => {
   const createdOn = props.currentApi.createdOn;
   const createdBy = props.currentApi.createdBy;
-
-
-// export class ApiDetailsView extends React.Component<ApiDetailsViewProps, ApiDetailsViewState> {
-//   constructor(props: ApiDetailsViewProps) {
-//     super(props);
-//     this.state = {
-//       activeTabKey: 0
-//     };
-//   }
-
-//   render() {
-//     // const { createdOn, createdBy} = this.props;
-//     console.log(`apiDetailsView props is: ${JSON.stringify(this.props)}`);
 
     return (
       <React.Fragment>
@@ -49,5 +25,4 @@ export const ApiDetailsView: React.FunctionComponent<ApiDetailsViewProps> = (pro
       );
   }
 
-// }
 export default ApiDetailsView;

--- a/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
+++ b/packages/studio/src/app/components/api/apiDetailsView/apiDetailsView.tsx
@@ -1,38 +1,37 @@
 import React, { useContext } from 'react';
-import { Grid, GridItem } from '@patternfly/react-core';
-import {GlobalContext, GlobalContextObj, DashboardViews} from '../../../../context';
-import ApiDataListState from '../apiDataList/apiDataListItem';
+import { UserIcon, UsersIcon, OutlinedClockIcon } from '@patternfly/react-icons';
 import './apiDetailsView.css';
+import moment from "moment";
 
-export const ApiDetailsView: React.FunctionComponent = () => {
-
-  function findId(array: any[], id: string) {
-    const apiTemp = array.find(api => api.id === id);
-    if (apiTemp !== undefined) {
-      return apiTemp;
-    }
-    else {
-      return Error;
-    }
+export interface ApiDetailsViewProps {
+  createdBy: string,
+  createdOn: Date,
+}
+interface ApiDetailsViewState {
+  activeTabKey: number
+}
+export class ApiDetailsView extends React.Component<ApiDetailsViewProps, ApiDetailsViewState> {
+  constructor(props: ApiDetailsViewProps) {
+    super(props);
+    this.state = {
+      activeTabKey: 0
+    };
   }
-
-  const currentId = ApiDataListState;
-
-  const { apis } = {... useContext(GlobalContext).store}
-  // const apiObject = findId(apis, props.currentApiId);
-
-  // const globalContext: GlobalContextObj = useContext(GlobalContext);
-  
+  render() {
+    const { createdOn, createdBy} = this.props;
     return (
-    <div className="api-details-content">
-        <p><b>Details</b></p>
-        <p>Created on {}</p>
-        <p>Created by {}</p>
-        <p>{} Other collaborators</p>
-        <br />
-        <p><b>Collaborators</b></p>
-    </div>
-    );
+      <React.Fragment>
+      <div className="api-details-content">
+          <h3>Details</h3>
+          <p><OutlinedClockIcon /><span>Created on {moment(createdOn).format('MMM DD, YYYY')}</span></p>
+          <p><UserIcon /><span>Created by {createdBy}</span></p>
+          <p><UsersIcon /><span>Other collaborators {}</span></p>
+          <br />
+          <h3>Collaborators</h3>
+      </div>
+      </React.Fragment>
+      );
   }
+}
 
 export default ApiDetailsView;

--- a/packages/studio/src/app/components/api/apiDetailsView/index.ts
+++ b/packages/studio/src/app/components/api/apiDetailsView/index.ts
@@ -1,0 +1,1 @@
+export * from './apiDetailsView';

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawer.css
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawer.css
@@ -9,3 +9,7 @@
   .api-drawer-panel-body .pf-c-drawer__panel-body {
     padding: 0;
   }
+
+  .api-drawer-panel-button {
+    margin-right: 4px;
+  }

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Drawer, DrawerPanelContent, DrawerContent } from '@patternfly/react-core/dist/esm/experimental';
-import AppDataList from '../apiDataList/apiDataList';
+import ApiDataList from '../apiDataList/apiDataList';
 import {ApiCardView} from '../..';
 import ApiDrawerPanelContent from './apiDrawerPanelContent';
 import './apiDrawer.css';
@@ -33,7 +33,7 @@ export class ApiDrawer extends React.Component<ApiDrawerProps, ApiDrawerState> {
           <div className="api-drawer-content">
             { 
             this.props.dashboardView === 'list' ? (
-              <AppDataList keyListItem={this.findKey} selectItem={this.openDrawer} viewDetails={this.openDrawer}/>
+              <ApiDataList keyListItem={this.findKey} selectItem={this.openDrawer} viewDetails={this.openDrawer}/>
              ) : (
             <ApiCardView/>
             )

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Drawer, DrawerPanelContent, DrawerContent } from '@patternfly/react-core/dist/esm/experimental';
 import ApiDataList from '../apiDataList/apiDataList';
 import {ApiCardView} from '../..';
 import ApiDrawerPanelContent from './apiDrawerPanelContent';
+import { GlobalContext, GlobalContextObj } from '../../../../context';
 import './apiDrawer.css';
 
 export interface ApiDrawerProps {
@@ -14,26 +15,31 @@ interface ApiDrawerState {
   readonly isExpanded: boolean,
 }
 
-export class ApiDrawer extends React.Component<ApiDrawerProps, ApiDrawerState> {
-  constructor(props: ApiDrawerProps) {
-    super(props);
-    this.state = {
-      currentApiId: "",
-      isExpanded: false
-    };
+export const ApiDrawer: React.FunctionComponent<ApiDrawerProps> = (props) => {
+  const globalContext: GlobalContextObj = useContext(GlobalContext);
+  const { apis,  apiDrawerExpanded } = {... useContext(GlobalContext).store};
+  const { store } = useContext(GlobalContext);
+  const setSelectedApiState = (selectedApiState: string) => {
+    globalContext.setSelectedApiId(selectedApiState);
   }
 
-  render() {
-   const { isExpanded, currentApiId } = this.state;
+  function openDrawer() {
+    const isExpanded = !apiDrawerExpanded;
+  };
+
+  function findKey(id: string) {
+    const keyListItem = id;
+    setSelectedApiState(keyListItem);
+  }  
 
    return (
     <React.Fragment>
-      <Drawer isExpanded={isExpanded} isInline className="app-drawer-drawer">
+      <Drawer isExpanded={apiDrawerExpanded} isInline className="app-drawer-drawer">
         <DrawerContent>
           <div className="api-drawer-content">
             { 
-            this.props.dashboardView === 'list' ? (
-              <ApiDataList keyListItem={this.findKey} selectItem={this.openDrawer} viewDetails={this.openDrawer}/>
+            props.dashboardView === 'list' ? (
+              <ApiDataList keyListItem={findKey} selectItem={openDrawer} viewDetails={openDrawer}/>
              ) : (
             <ApiCardView/>
             )
@@ -41,26 +47,11 @@ export class ApiDrawer extends React.Component<ApiDrawerProps, ApiDrawerState> {
           </div>
         </DrawerContent>
         <DrawerPanelContent className="api-drawer-panel-body">
-          <ApiDrawerPanelContent currentApiId={currentApiId}/>
+          <ApiDrawerPanelContent currentApiId={globalContext.store.selectedApiId}/>
         </DrawerPanelContent>
       </Drawer>
     </React.Fragment>
     );
  }
-
-  public openDrawer = () => {
-    const isExpanded = !this.state.isExpanded;
-    this.setState({
-      isExpanded
-    });
-  };
-
-  private findKey = (id: string) => {
-    const keyListItem = id;
-    this.setState({
-      currentApiId: keyListItem
-    })
-  }
-}
 
 export default ApiDrawer;

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
@@ -28,7 +28,7 @@ export class ApiDrawer extends React.Component<ApiDrawerProps, ApiDrawerState> {
 
    return (
     <React.Fragment>
-      <Drawer isExpanded={isExpanded} isInline className="app-drawer-drawer">
+      <Drawer isExpanded={isExpanded} isInline="true" className="app-drawer-drawer">
         <DrawerContent>
           <div className="api-drawer-content">
             { 

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
@@ -28,7 +28,7 @@ export class ApiDrawer extends React.Component<ApiDrawerProps, ApiDrawerState> {
 
    return (
     <React.Fragment>
-      <Drawer isExpanded={isExpanded} isInline="true" className="app-drawer-drawer">
+      <Drawer isExpanded={isExpanded} isInline className="app-drawer-drawer">
         <DrawerContent>
           <div className="api-drawer-content">
             { 
@@ -48,7 +48,7 @@ export class ApiDrawer extends React.Component<ApiDrawerProps, ApiDrawerState> {
     );
  }
 
-  private openDrawer = () => {
+  public openDrawer = () => {
     const isExpanded = !this.state.isExpanded;
     this.setState({
       isExpanded

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawer.tsx
@@ -17,8 +17,7 @@ interface ApiDrawerState {
 
 export const ApiDrawer: React.FunctionComponent<ApiDrawerProps> = (props) => {
   const globalContext: GlobalContextObj = useContext(GlobalContext);
-  const { apis,  apiDrawerExpanded } = {... useContext(GlobalContext).store};
-  const { store } = useContext(GlobalContext);
+  const { apiDrawerExpanded } = {... useContext(GlobalContext).store};
   const setSelectedApiState = (selectedApiState: string) => {
     globalContext.setSelectedApiId(selectedApiState);
   }
@@ -39,7 +38,7 @@ export const ApiDrawer: React.FunctionComponent<ApiDrawerProps> = (props) => {
           <div className="api-drawer-content">
             { 
             props.dashboardView === 'list' ? (
-              <ApiDataList keyListItem={findKey} selectItem={openDrawer} viewDetails={openDrawer}/>
+              <ApiDataList keyListItem={findKey} selectItem={setSelectedApiState} viewDetails={openDrawer}/>
              ) : (
             <ApiCardView/>
             )
@@ -47,7 +46,7 @@ export const ApiDrawer: React.FunctionComponent<ApiDrawerProps> = (props) => {
           </div>
         </DrawerContent>
         <DrawerPanelContent className="api-drawer-panel-body">
-          <ApiDrawerPanelContent currentApiId={globalContext.store.selectedApiId}/>
+          <ApiDrawerPanelContent />
         </DrawerPanelContent>
       </Drawer>
     </React.Fragment>

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -3,12 +3,11 @@ import { Button, Card, CardActions, CardHead, CardBody, Title } from '@patternfl
 import {TimesIcon, EyeIcon} from '@patternfly/react-icons';
 import ApicurioIcon from '../../../assets/apicurio-icon.png';
 import { ApiTabs } from '../apiTabs';
-import { GlobalContext } from '../../../../context';
+import { GlobalContext, GlobalContextObj } from '../../../../context';
 import './apiDrawer.css';
 
 export interface ApiDrawerPanelContentProps {
-  currentApiId: string,
-  apiDrawerExpanded: boolean
+  currentApiId: string
 }
 
 function findId(array: any[], id: string) {
@@ -22,9 +21,14 @@ function findId(array: any[], id: string) {
 }
 
 export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelContentProps> = (props) => {
-  const { apis } = {... useContext(GlobalContext).store};
+  const { apis,  apiDrawerExpanded } = {... useContext(GlobalContext).store};
+  const { store } = useContext(GlobalContext);
+  const globalContext: GlobalContextObj = useContext(GlobalContext);
+  const setApiDrawerState = (apiDrawerState: boolean) => {
+    globalContext.setApiDrawerExpanded(!apiDrawerState);
+  }
   const apiObject = findId(apis, props.currentApiId);
-  console.log(`apiDrawerPanelContent props is: ${JSON.stringify(props)}`);
+
 
     return (
       <Card>
@@ -36,7 +40,7 @@ export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelConten
             </Title>
           </span>
           <CardActions>
-            <Button variant="plain" aria-label="Action">
+            <Button onClick={() => setApiDrawerState(store.apiDrawerExpanded)} variant="plain" aria-label="Action">
               <TimesIcon/>
             </Button>
           </CardActions>

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -21,8 +21,7 @@ function findId(array: any[], id: string) {
 
 export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelContentProps> = (props) => {
   const { apis } = {... useContext(GlobalContext).store};
-
-    const apiObject = findId(apis, props.currentApiId);
+  const apiObject = findId(apis, props.currentApiId);
 
     return (
       <Card>

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -6,10 +6,6 @@ import { ApiTabs } from '../apiTabs';
 import { GlobalContext, GlobalContextObj } from '../../../../context';
 import './apiDrawer.css';
 
-export interface ApiDrawerPanelContentProps {
-  currentApiId: string
-}
-
 function findId(array: any[], id: string) {
   const apiTemp = array.find(api => api.id === id);
   if (apiTemp !== undefined) {
@@ -20,15 +16,13 @@ function findId(array: any[], id: string) {
   }
 }
 
-export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelContentProps> = (props) => {
-  const { apis,  apiDrawerExpanded } = {... useContext(GlobalContext).store};
-  const { store } = useContext(GlobalContext);
+export const ApiDrawerPanelContent: React.FunctionComponent = () => {
+  const { apis,  apiDrawerExpanded, selectedApiId } = {... useContext(GlobalContext).store};
   const globalContext: GlobalContextObj = useContext(GlobalContext);
   const setApiDrawerState = (apiDrawerState: boolean) => {
     globalContext.setApiDrawerExpanded(!apiDrawerState);
   }
-  const apiObject = findId(apis, props.currentApiId);
-
+  const apiObject = findId(apis, selectedApiId);
 
     return (
       <Card>
@@ -40,7 +34,7 @@ export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelConten
             </Title>
           </span>
           <CardActions>
-            <Button onClick={() => setApiDrawerState(store.apiDrawerExpanded)} variant="plain" aria-label="Action">
+            <Button onClick={() => setApiDrawerState(apiDrawerExpanded)} variant="plain" aria-label="Action">
               <TimesIcon/>
             </Button>
           </CardActions>
@@ -56,7 +50,7 @@ export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelConten
             </Button>
           </div>
         </CardBody>
-        <ApiTabs currentApiObject={apiObject}/>
+        <ApiTabs currentApiObject={apiObject} />
       </Card>
     )
   }

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -20,7 +20,7 @@ function findId(array: any[], id: string) {
 }
 
 export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelContentProps> = (props) => {
-  const { apis } = {... useContext(GlobalContext).store}
+  const { apis } = {... useContext(GlobalContext).store};
 
     const apiObject = findId(apis, props.currentApiId);
 

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -1,22 +1,28 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button, Card, CardActions, CardHead, CardBody, Title } from '@patternfly/react-core';
 import {TimesIcon, EyeIcon} from '@patternfly/react-icons';
 import ApicurioIcon from '../../../assets/apicurio-icon.png';
 import { ApiTabs } from '../apiTabs';
-import data from '../../../../api-data.json';
+import { GlobalContext } from '../../../../context';
 
 export interface ApiDrawerPanelContentProps {
   currentApiId: string
 }
 
-export class ApiDrawerPanelContent extends React.Component<ApiDrawerPanelContentProps> {
-;
-  constructor(props: ApiDrawerPanelContentProps) {
-    super(props);
+function findId(array: any[], id: string) {
+  const apiTemp = array.find(api => api.id === id);
+  if (apiTemp !== undefined) {
+    return apiTemp;
   }
+  else {
+    return Error;
+  }
+}
 
-  render() {
-    const apiObject = this.findId(data.apis, this.props.currentApiId);
+export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelContentProps> = (props) => {
+  const { apis } = {... useContext(GlobalContext).store}
+
+    const apiObject = findId(apis, props.currentApiId);
 
     return (
       <Card>
@@ -48,15 +54,5 @@ export class ApiDrawerPanelContent extends React.Component<ApiDrawerPanelContent
       </Card>
     )
   }
-   private findId = (array: any[], id: string): any => {
-    const apiTemp = array.find(api => api.id === id);
-    if (apiTemp !== undefined) {
-      return apiTemp;
-    }
-    else {
-      return Error;
-    }
-  }
-}
 
 export default ApiDrawerPanelContent;

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -4,6 +4,7 @@ import {TimesIcon, EyeIcon} from '@patternfly/react-icons';
 import ApicurioIcon from '../../../assets/apicurio-icon.png';
 import { ApiTabs } from '../apiTabs';
 import { GlobalContext } from '../../../../context';
+import './apiDrawer.css';
 
 export interface ApiDrawerPanelContentProps {
   currentApiId: string
@@ -40,8 +41,8 @@ export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelConten
         </CardHead>
         <CardBody>
           <div className="app-button-group-sm">
-            <Button variant="tertiary" className="pf-u-mr-sm">
-              <EyeIcon/>
+            <Button variant="tertiary">
+              <EyeIcon className='api-drawer-panel-button'/>
               Preview documentation
             </Button>
             <Button variant="secondary">

--- a/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
+++ b/packages/studio/src/app/components/api/apiDrawer/apiDrawerPanelContent.tsx
@@ -7,7 +7,8 @@ import { GlobalContext } from '../../../../context';
 import './apiDrawer.css';
 
 export interface ApiDrawerPanelContentProps {
-  currentApiId: string
+  currentApiId: string,
+  apiDrawerExpanded: boolean
 }
 
 function findId(array: any[], id: string) {
@@ -23,6 +24,7 @@ function findId(array: any[], id: string) {
 export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelContentProps> = (props) => {
   const { apis } = {... useContext(GlobalContext).store};
   const apiObject = findId(apis, props.currentApiId);
+  console.log(`apiDrawerPanelContent props is: ${JSON.stringify(props)}`);
 
     return (
       <Card>
@@ -50,7 +52,7 @@ export const ApiDrawerPanelContent: React.FunctionComponent<ApiDrawerPanelConten
             </Button>
           </div>
         </CardBody>
-        <ApiTabs createdBy={apiObject.createdBy} createdOn={apiObject.createdOn}/>
+        <ApiTabs currentApiObject={apiObject}/>
       </Card>
     )
   }

--- a/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
+++ b/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
@@ -4,8 +4,6 @@ import { ApiDetailsView } from '../apiDetailsView';
 import { ApiActivityView } from '../apiActivityView';
 
 export interface ApiTabsProps {
-  // createdBy: string,
-  // createdOn: Date
   currentApiObject: string
 }
 
@@ -30,17 +28,17 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
     return (
       <React.Fragment>
         <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-          <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}/>
-          <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
+          <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}>
+            <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
+              <ApiDetailsView currentApi={this.props.currentApiObject} />
+            </TabContent>
+          </Tab>
+          <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}>
+            <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
+              <ApiActivityView currentApi={this.props.currentApiObject} />
+            </TabContent>
+          </Tab>
         </Tabs>
-        <div>
-          <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
-            <ApiDetailsView currentApi={this.props.currentApiObject} />
-          </TabContent>
-          <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
-            <ApiActivityView />
-          </TabContent>
-        </div>
       </React.Fragment>
     );
   }

--- a/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
+++ b/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
@@ -4,8 +4,9 @@ import { ApiDetailsView } from '../apiDetailsView';
 import { ApiActivityView } from '../apiActivityView';
 
 export interface ApiTabsProps {
-  createdBy: string,
-  createdOn: Date
+  // createdBy: string,
+  // createdOn: Date
+  currentApiObject: string
 }
 
 interface ApiTabsState {
@@ -24,7 +25,7 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
   }
 
   render() {
-    const { createdOn, createdBy} = this.props;
+    // const { createdOn, createdBy} = this.props;
 
     return (
       <React.Fragment>
@@ -34,7 +35,7 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
         </Tabs>
         <div>
           <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
-            <ApiDetailsView createdBy={createdBy} createdOn={createdOn} />
+            <ApiDetailsView currentApi={this.props.currentApiObject} />
           </TabContent>
           <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
             <ApiActivityView />

--- a/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
+++ b/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Tabs, Tab, TabContent } from '@patternfly/react-core';
-
+import { Grid, GridItem, Tabs, Tab, TabContent } from '@patternfly/react-core';
+import { ApiDetailsView } from '../apiDetailsView';
+import { ApiActivityView } from '../apiActivityView';
 
 export interface ApiTabsProps {
   createdBy: string,
@@ -13,8 +14,8 @@ interface ApiTabsState {
 
 export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
 
-  private contentRef1 = React.createRef();
-  private contentRef2 = React.createRef();
+  private detailsContentRef = React.createRef();
+  private activityContentRef = React.createRef();
   constructor(props: ApiTabsProps) {
     super(props);
     this.state = {
@@ -27,17 +28,23 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
     return (
       <React.Fragment>
         <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-          <Tab eventKey={0} title="Details" tabContentId="refTab1Section" tabContentRef={this.contentRef1}/>
-          <Tab eventKey={1} title="Activity" tabContentId="refTab2Section" tabContentRef={this.contentRef2}/>
+          <Tab eventKey={0} title="Details" tabContentId="apiDetails" tabContentRef={this.detailsContentRef}/>
+          <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
         </Tabs>
         <div>
-          <TabContent eventKey={0} id="refTab1Section" ref={this.contentRef1} aria-label="Tab item 1">
-            Tab 1 section
-            {createdOn}
-            {createdBy}
+        <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
+          <Grid>
+            <GridItem sm={12} md={12}>
+              <ApiDetailsView />
+            </GridItem>
+          </Grid>
           </TabContent>
-          <TabContent eventKey={1} id="refTab12ection" ref={this.contentRef2} aria-label="Tab item 2">
-            Tab 2 section
+          <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
+          <Grid>
+            <GridItem sm={12} md={12}>
+              <ApiActivityView />
+            </GridItem>
+          </Grid>
           </TabContent>
         </div>
       </React.Fragment>

--- a/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
+++ b/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
@@ -25,6 +25,7 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
 
   render() {
     const { createdOn, createdBy} = this.props;
+
     return (
       <React.Fragment>
         <Tabs isFilled={true} activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
@@ -35,7 +36,7 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
         <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
           <Grid>
             <GridItem sm={12} md={12}>
-              <ApiDetailsView />
+              <ApiDetailsView createdBy={createdBy} createdOn={createdOn} />
             </GridItem>
           </Grid>
           </TabContent>

--- a/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
+++ b/packages/studio/src/app/components/api/apiTabs/apiTabs.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Grid, GridItem, Tabs, Tab, TabContent } from '@patternfly/react-core';
+import { Tabs, Tab, TabContent } from '@patternfly/react-core';
 import { ApiDetailsView } from '../apiDetailsView';
 import { ApiActivityView } from '../apiActivityView';
 
 export interface ApiTabsProps {
   createdBy: string,
-  createdOn: Date,
+  createdOn: Date
 }
 
 interface ApiTabsState {
@@ -33,19 +33,11 @@ export class ApiTabs extends React.Component<ApiTabsProps, ApiTabsState> {
           <Tab eventKey={1} title="Activity" tabContentId="apiActivity" tabContentRef={this.activityContentRef}/>
         </Tabs>
         <div>
-        <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
-          <Grid>
-            <GridItem sm={12} md={12}>
-              <ApiDetailsView createdBy={createdBy} createdOn={createdOn} />
-            </GridItem>
-          </Grid>
+          <TabContent eventKey={0} id="apiDetails" ref={this.detailsContentRef} aria-label="API details tab">
+            <ApiDetailsView createdBy={createdBy} createdOn={createdOn} />
           </TabContent>
           <TabContent eventKey={1} id="apiActivity" ref={this.activityContentRef} aria-label="API activity tab">
-          <Grid>
-            <GridItem sm={12} md={12}>
-              <ApiActivityView />
-            </GridItem>
-          </Grid>
+            <ApiActivityView />
           </TabContent>
         </div>
       </React.Fragment>

--- a/packages/studio/src/app/components/api/apiToolbar/apiToolbar.tsx
+++ b/packages/studio/src/app/components/api/apiToolbar/apiToolbar.tsx
@@ -8,6 +8,8 @@ export const ApiToolbar: React.FunctionComponent = () => {
 
   const globalContext: GlobalContextObj = useContext(GlobalContext);
 
+  const apiCount = globalContext.store.apis.length;
+
   return (
     <DataToolbar id="apiToolbar">
       <DataToolbarContent>
@@ -22,7 +24,7 @@ export const ApiToolbar: React.FunctionComponent = () => {
             <ListIcon/>
           </Button>
           <span className="app-toolbar-api-total">
-            4 APIs found
+            {apiCount} APIs found
           </span>
         </DataToolbarItem>
       </DataToolbarContent>

--- a/packages/studio/src/app/pages/dashboard/dashboard.tsx
+++ b/packages/studio/src/app/pages/dashboard/dashboard.tsx
@@ -23,7 +23,7 @@ export const Dashboard = () => {
         globalContext.updateApis(apis);
       })
       .catch(error => {
-        console.error("error getting API" + error);
+        console.error("error getting API " + error);
       });
 
     await userService.getActivity(activityStart, activityEnd)
@@ -36,9 +36,8 @@ export const Dashboard = () => {
         return activityData;
       })
       .catch(error => {
-        console.error("error getting API" + error);
+        console.error("error getting activities " + error);
       });
-
     }
 
   useEffect(() => {

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -20,7 +20,7 @@ const initialState: GlobalState = {
     apis: [],
     dashboardView: DashboardViews.list,
     notificationDrawerExpanded: false,
-    recentActivity: [],
+    recentActivity: []
 };
 
 export interface GlobalContextObj {

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -6,7 +6,6 @@ export interface GlobalState {
     recentActivity: ApiDesignChange[],
     dashboardView: DashboardViews,
     notificationDrawerExpanded: boolean,
-    selectedApiId: string
 }
 
 /**
@@ -22,7 +21,6 @@ const initialState: GlobalState = {
     dashboardView: DashboardViews.list,
     notificationDrawerExpanded: false,
     recentActivity: [],
-    selectedApiId: ""
 };
 
 export interface GlobalContextObj {
@@ -31,7 +29,6 @@ export interface GlobalContextObj {
     setNotificationDrawerExpanded: (isExpanded: boolean) => void,
     updateApis: (apis: Api[]) => void,
     updateRecentActivity: (recentActivity: ApiDesignChange[]) => void,
-    setSelectedApiId: (selectedApiId: string) => void
 };
 
 export const GlobalContext = React.createContext({} as GlobalContextObj);
@@ -44,7 +41,6 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
             <GlobalContext.Provider value={{
                 setDashboardView: this.setDashboardView,
                 setNotificationDrawerExpanded: this.setNotificationDrawerExpanded,
-                setSelectedApiId: this.setSelectedApiId,
                 store: this.state,
                 updateApis: this.updateApis,
                 updateRecentActivity: this.updateRecentActivity
@@ -68,9 +64,5 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
 
     private updateRecentActivity = (recentActivity: ApiDesignChange[]) => {
         this.setState({recentActivity})
-    }
-
-    private setSelectedApiId = (selectedApiId: string) => {
-        this.setState({selectedApiId})
     }
 };

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createContext } from 'react';
 import {Api, ApiDesignChange} from "@apicurio/models";
 
 export interface GlobalState {
@@ -6,7 +6,8 @@ export interface GlobalState {
     recentActivity: ApiDesignChange[],
     dashboardView: DashboardViews,
     notificationDrawerExpanded: boolean,
-    apiDrawerExpanded: boolean
+    apiDrawerExpanded: boolean,
+    selectedApiId: string
 }
 
 /**
@@ -22,11 +23,13 @@ const initialState: GlobalState = {
     apis: [],
     dashboardView: DashboardViews.list,
     notificationDrawerExpanded: false,
-    recentActivity: []
+    recentActivity: [],
+    selectedApiId: ''
 };
 
 export interface GlobalContextObj {
     setApiDrawerExpanded: (isExpanded: boolean) => void,
+    setSelectedApiId: (selectedApiId: string) => void,
     store: GlobalState,
     setDashboardView: (view: DashboardViews) => void,
     setNotificationDrawerExpanded: (isExpanded: boolean) => void,
@@ -34,7 +37,7 @@ export interface GlobalContextObj {
     updateRecentActivity: (recentActivity: ApiDesignChange[]) => void,
 };
 
-export const GlobalContext = React.createContext({} as GlobalContextObj);
+export const GlobalContext = createContext({} as GlobalContextObj);
 
 export class GlobalContextProvider extends React.Component<{}, GlobalState> {
     state: GlobalState = initialState;
@@ -45,6 +48,7 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
                 setApiDrawerExpanded: this.setApiDrawerExpanded,
                 setDashboardView: this.setDashboardView,
                 setNotificationDrawerExpanded: this.setNotificationDrawerExpanded,
+                setSelectedApiId: this.setSelectedApiId,
                 store: this.state,
                 updateApis: this.updateApis,
                 updateRecentActivity: this.updateRecentActivity
@@ -56,6 +60,10 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
 
     private setApiDrawerExpanded = (apiDrawerExpanded: boolean) => {
         this.setState({apiDrawerExpanded})
+    }
+
+    private setSelectedApiId = (selectedApiId: string) => {
+        this.setState({selectedApiId})
     }
 
     private setDashboardView = (dashboardView: DashboardViews) => {

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -1,8 +1,9 @@
 import React, { createContext } from 'react';
-import {Api, ApiDesignChange} from "@apicurio/models";
+import {Api, ApiDesignChange, ApiCollaborator} from "@apicurio/models";
 
 export interface GlobalState {
     apis: Api[],
+    collaborators: ApiCollaborator[],
     recentActivity: ApiDesignChange[],
     dashboardView: DashboardViews,
     notificationDrawerExpanded: boolean,
@@ -21,6 +22,7 @@ export enum DashboardViews {
 const initialState: GlobalState = {
     apiDrawerExpanded: false,
     apis: [],
+    collaborators: [],
     dashboardView: DashboardViews.list,
     notificationDrawerExpanded: false,
     recentActivity: [],
@@ -34,6 +36,7 @@ export interface GlobalContextObj {
     setDashboardView: (view: DashboardViews) => void,
     setNotificationDrawerExpanded: (isExpanded: boolean) => void,
     updateApis: (apis: Api[]) => void,
+    updateCollaborators: (collaborators: ApiCollaborator[]) => void,
     updateRecentActivity: (recentActivity: ApiDesignChange[]) => void,
 };
 
@@ -51,6 +54,7 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
                 setSelectedApiId: this.setSelectedApiId,
                 store: this.state,
                 updateApis: this.updateApis,
+                updateCollaborators: this.updateCollaborators,
                 updateRecentActivity: this.updateRecentActivity
             }}>
                 {this.props.children}
@@ -76,6 +80,10 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
 
     private updateApis = (apis: Api[]) => {
         this.setState({apis})
+    }
+
+    private updateCollaborators = (collaborators: ApiCollaborator[]) => {
+        this.setState({collaborators})
     }
 
     private updateRecentActivity = (recentActivity: ApiDesignChange[]) => {

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -5,7 +5,8 @@ export interface GlobalState {
     apis: Api[],
     recentActivity: ApiDesignChange[],
     dashboardView: DashboardViews,
-    notificationDrawerExpanded: boolean
+    notificationDrawerExpanded: boolean,
+    selectedApiId: string
 }
 
 /**
@@ -20,7 +21,8 @@ const initialState: GlobalState = {
     apis: [],
     dashboardView: DashboardViews.list,
     notificationDrawerExpanded: false,
-    recentActivity: []
+    recentActivity: [],
+    selectedApiId: ""
 };
 
 export interface GlobalContextObj {
@@ -28,11 +30,11 @@ export interface GlobalContextObj {
     setDashboardView: (view: DashboardViews) => void,
     setNotificationDrawerExpanded: (isExpanded: boolean) => void,
     updateApis: (apis: Api[]) => void,
-    updateRecentActivity: (recentActivity: ApiDesignChange[]) => void
+    updateRecentActivity: (recentActivity: ApiDesignChange[]) => void,
+    setSelectedApiId: (selectedApiId: string) => void
 };
 
 export const GlobalContext = React.createContext({} as GlobalContextObj);
-
 
 export class GlobalContextProvider extends React.Component<{}, GlobalState> {
     state: GlobalState = initialState;
@@ -42,6 +44,7 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
             <GlobalContext.Provider value={{
                 setDashboardView: this.setDashboardView,
                 setNotificationDrawerExpanded: this.setNotificationDrawerExpanded,
+                setSelectedApiId: this.setSelectedApiId,
                 store: this.state,
                 updateApis: this.updateApis,
                 updateRecentActivity: this.updateRecentActivity
@@ -62,7 +65,12 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
     private updateApis = (apis: Api[]) => {
         this.setState({apis})
     }
+
     private updateRecentActivity = (recentActivity: ApiDesignChange[]) => {
         this.setState({recentActivity})
+    }
+
+    private setSelectedApiId = (selectedApiId: string) => {
+        this.setState({selectedApiId})
     }
 };

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -6,6 +6,7 @@ export interface GlobalState {
     recentActivity: ApiDesignChange[],
     dashboardView: DashboardViews,
     notificationDrawerExpanded: boolean,
+    apiDrawerExpanded: boolean
 }
 
 /**
@@ -17,6 +18,7 @@ export enum DashboardViews {
 }
 
 const initialState: GlobalState = {
+    apiDrawerExpanded: false,
     apis: [],
     dashboardView: DashboardViews.list,
     notificationDrawerExpanded: false,
@@ -24,6 +26,7 @@ const initialState: GlobalState = {
 };
 
 export interface GlobalContextObj {
+    setApiDrawerExpanded: (isExpanded: boolean) => void,
     store: GlobalState,
     setDashboardView: (view: DashboardViews) => void,
     setNotificationDrawerExpanded: (isExpanded: boolean) => void,
@@ -39,6 +42,7 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
     render() {
         return (
             <GlobalContext.Provider value={{
+                setApiDrawerExpanded: this.setApiDrawerExpanded,
                 setDashboardView: this.setDashboardView,
                 setNotificationDrawerExpanded: this.setNotificationDrawerExpanded,
                 store: this.state,
@@ -48,6 +52,10 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
                 {this.props.children}
             </GlobalContext.Provider>
         );
+    }
+
+    private setApiDrawerExpanded = (apiDrawerExpanded: boolean) => {
+        this.setState({apiDrawerExpanded})
     }
 
     private setDashboardView = (dashboardView: DashboardViews) => {


### PR DESCRIPTION
**Added various functionality:**
- Activity tab contents
- Details tab contents
- Card view button and API counter (dashboard) 
- View details button (now works and opens the api drawer as opposed to selecting the datalist item)
- Close button (x) on drawer
- Fixed issue in which both tab's (details/activity) contents were displaying on initial view
- Fixed issue in which api activity was displaying in its entirety as opposed to per API

**Known issues:**
- Not retrieving collaborators on the details tab. I left some code in there as a starting point to revisit at a later time.
- If you click the View Details button w/o selecting the datalist row first, the drawer's data will not be populated. So for now to see it working, select the row and then select the View Details button. Obviously a bug that needs to be investigated, but wanted to get what I've done into the working branch in the interim.