### PR TITLE
Create API: Add redirect and select newest created API

### DIFF
--- a/packages/studio/src/app/components/api/apiDataList/apiDataList.tsx
+++ b/packages/studio/src/app/components/api/apiDataList/apiDataList.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useState, useContext, useEffect} from 'react';
 import {DataList} from '@patternfly/react-core';
 import ApiDataListItem from './apiDataListItem';
+import { GlobalContext, GlobalContextObj } from '../../../../context';
 
 interface ApiDataListProps {
   viewDetails: React.MouseEventHandler,
@@ -8,35 +9,33 @@ interface ApiDataListProps {
   keyListItem: FunctionStringCallback
 }
 
-interface ApiDataListState {
-  selectedDataListItemId: string
-}
+export const ApiDataList: React.FunctionComponent<ApiDataListProps> = () => {
 
-class ApiDataList extends React.Component<ApiDataListProps, ApiDataListState> {
-  constructor(props: ApiDataListProps) {
-    super(props);
-    this.state = {
-      selectedDataListItemId: ''
-    };
+  const globalContext: GlobalContextObj = useContext(GlobalContext);
+  const [selectedDataListItemId, setSelectedDataListItemId] = useState('');
+
+  const onSelectDataListItem = (id: string) => {
+    if (globalContext.store.lastCreatedApi !== '') {
+      globalContext.setLastCreatedApi('');
+    }
+    setSelectedDataListItemId(id);
   }
 
-  onSelectDataListItem = (id: string) => {
-    this.setState({ selectedDataListItemId: id });
-    this.props.selectItem(id);
-    this.props.keyListItem(id);
-  }
+  useEffect(() => {
+    if (globalContext.store.lastCreatedApi !== '') {
+      setSelectedDataListItemId(globalContext.store.lastCreatedApi);
+    }
+  });
 
-  render() {
-    return (
-      <DataList 
-        aria-label="selectable data list"
-        selectedDataListItemId={this.state.selectedDataListItemId}
-        onSelectDataListItem={this.onSelectDataListItem}
-      >
-        <ApiDataListItem />
-      </DataList>
-    );
-  }
-}
+  return (
+    <DataList 
+      aria-label="Selectable data list"
+      selectedDataListItemId={selectedDataListItemId}
+      onSelectDataListItem={onSelectDataListItem}
+    >
+      <ApiDataListItem />
+    </DataList>
+  );
+};
 
 export default ApiDataList;

--- a/packages/studio/src/app/pages/api/createApi.tsx
+++ b/packages/studio/src/app/pages/api/createApi.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect, useContext} from 'react';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -24,10 +24,13 @@ import './createApi.css';
 import { NewApi, ImportApi} from "@apicurio/models";
 import { CreateApiFormData } from '../../../../../models/src/create-api-form-data.model';
 import {Base64} from "js-base64";
+import { GlobalContext, GlobalContextObj } from '../../../context';
+import { Redirect } from "react-router-dom";
 
 export const CreateApi = () => {
 
   const apisService = Services.getInstance().apisService;
+  const globalContext: GlobalContextObj = useContext(GlobalContext);
 
   // TO DO: Add more options here
   const typeOptions = [
@@ -42,6 +45,7 @@ export const CreateApi = () => {
   const [isNameValid, setIsNameValid] = useState(true);
   const [countSubmit, setCountSubmit] = useState(0);
   const [isFormValid, setIsFormValid] = useState(false);
+  const [redirect, setRedirect] = useState(''); 
 
   const onChange = (apiType: string) => {
     setApiType(apiType);
@@ -102,10 +106,9 @@ export const CreateApi = () => {
       console.log("[CreateApiPageComponent] Creating a new (blank) API: " + JSON.stringify(newApi));
 
       apisService.createApi(newApi).then(api => {
-        // TO DO: Set up routes in the app to redirect here
-        // let link: string[] = ["/", api.id];
-        // console.info("[CreateApiPageComponent] Navigating to: %o", link);
-        // this.router.navigate(link);
+        globalContext.setLastCreatedApi(api.data.id);
+        console.info("[CreateApiPageComponent] Navigating to: Apis");
+        setRedirect('/');
         }).catch(error => {
         console.error("[CreateApiPageComponent] Error creating an API");
         // TO DO: Set up error handling
@@ -152,6 +155,7 @@ export const CreateApi = () => {
 
   return (
       <React.Fragment>
+        {redirect && <Redirect to={redirect}/>}
         <PageSection variant={PageSectionVariants.light} className="app-page-section-breadcrumb">
           <Breadcrumb>
             <BreadcrumbItem to="/">

--- a/packages/studio/src/context/GlobalContext.tsx
+++ b/packages/studio/src/context/GlobalContext.tsx
@@ -13,6 +13,7 @@ export interface GlobalState {
   recentActivity: ApiDesignChange[];
   notificationDrawerExpanded: boolean;
   dashboardView: DashboardViews;
+  lastCreatedApi: string;
   toolbarStatus: ToolbarStatus;
   apiDrawerExpanded: boolean;
   selectedApiId: string;
@@ -31,6 +32,7 @@ const initialState: GlobalState = {
   apis: [],
   collaborators: [],
   dashboardView: DashboardViews.list,
+  lastCreatedApi: "",
   notificationDrawerExpanded: false,
   recentActivity: [],
   selectedApiId: "",
@@ -47,6 +49,7 @@ export interface GlobalContextObj {
   store: GlobalState;
   setDashboardView: (view: DashboardViews) => void;
   setNotificationDrawerExpanded: (isExpanded: boolean) => void;
+  setLastCreatedApi: (lastCreatedApi: string) => void;
   updateApis: (apis: Api[]) => void;
   updateCollaborators: (collaborators: ApiCollaborator[]) => void;
   updateRecentActivity: (recentActivity: ApiDesignChange[]) => void;
@@ -64,6 +67,7 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
         value={{
           setApiDrawerExpanded: this.setApiDrawerExpanded,
           setDashboardView: this.setDashboardView,
+          setLastCreatedApi: this.setLastCreatedApi,
           setNotificationDrawerExpanded: this.setNotificationDrawerExpanded,
           setSelectedApiId: this.setSelectedApiId,
           store: this.state,
@@ -85,6 +89,10 @@ export class GlobalContextProvider extends React.Component<{}, GlobalState> {
   private setSelectedApiId = (selectedApiId: string) => {
     this.setState({ selectedApiId });
   };
+
+  private setLastCreatedApi = (lastCreatedApi: string) => {
+    this.setState({ lastCreatedApi });
+  }
 
   private setDashboardView = (dashboardView: DashboardViews) => {
     this.setState({ dashboardView });


### PR DESCRIPTION
Once an API is created, the application redirects to the home page and on the home page the newest created API is selected. Test this by creating a new API and making sure that it 1) redirects to the page, 2) the newest API is selected, 3) when you click on another API the selection changes to that API. And test for anything else you would expect.