### PR TITLE
fixes sorting bug for APIs with uppercase letters

### DIFF
--- a/packages/studio/src/app/components/api/apiToolbar/apiToolbar.tsx
+++ b/packages/studio/src/app/components/api/apiToolbar/apiToolbar.tsx
@@ -46,9 +46,9 @@ export const ApiToolbar = () => {
 
   const compare = (direction: string) => {
     if (direction === "asc") {
-      return (a: Api, b: Api) => (a.name > b.name ? 1 : -1);
+      return (a: Api, b: Api) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1);
     } else if (direction === "desc") {
-      return (a: Api, b: Api) => (b.name > a.name ? 1 : -1);
+      return (a: Api, b: Api) => (b.name.toLowerCase() > a.name.toLowerCase() ? 1 : -1);
     }
     return (a: Api, b: Api) => 0;
   };


### PR DESCRIPTION
Addresses API sorting order per @christiemolloy's comment in https://github.com/Apicurio/apicurio-studio-react-poc/pull/36#pullrequestreview-434241986. Comparing APIs in lowercase should fix the incorrect sorting order. 