### PR TITLE
Fixes loader errors for rh-uxd package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
     "nohoist": [
       "**/@patternfly/react-core",
       "**/@patternfly/react-core/**",
-      "**/patternfly"
+      "**/patternfly",
+      "**/@rh-uxd/integration-core",
+      "**/@rh-uxd/integration-core/**",
+      "**/@rh-uxd/integration-react",
+      "**/@rh-uxd/integration-react/**",
+      "**/rh-uxd"
     ]
   },
   "scripts": {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -17,8 +17,6 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@rh-uxd/integration-core": "1.0.3",
-    "@rh-uxd/integration-react": "1.0.3",
     "@types/enzyme": "^3.9.0",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.9",
@@ -65,8 +63,8 @@
     "@apicurio/services": "^1.0.0",
     "@patternfly/react-core": "^3.146.0",
     "@patternfly/react-icons": "^3.10.6",
-    "@rh-uxd/integration-core": "1.0.3",
-    "@rh-uxd/integration-react": "1.0.3",
+    "@rh-uxd/integration-core": "^1.0.3",
+    "@rh-uxd/integration-react": "^1.0.3",
     "@types/react-router": "^5.0.3",
     "@types/react-router-dom": "^4.3.4",
     "apicurio-data-models": "^1.0.4",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -17,6 +17,8 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
+    "@rh-uxd/integration-core": "1.0.3",
+    "@rh-uxd/integration-react": "1.0.3",
     "@types/enzyme": "^3.9.0",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.9",
@@ -63,6 +65,8 @@
     "@apicurio/services": "^1.0.0",
     "@patternfly/react-core": "^3.146.0",
     "@patternfly/react-icons": "^3.10.6",
+    "@rh-uxd/integration-core": "1.0.3",
+    "@rh-uxd/integration-react": "1.0.3",
     "@types/react-router": "^5.0.3",
     "@types/react-router-dom": "^4.3.4",
     "apicurio-data-models": "^1.0.4",

--- a/packages/studio/src/app/app.tsx
+++ b/packages/studio/src/app/app.tsx
@@ -4,35 +4,21 @@ import AppHeader from "./appHeader";
 import {BrowserRouter as Router, Route} from 'react-router-dom';
 import * as Pages from './pages';
 import './app.css';
-import { LoadingPage } from '@rh-uxd/integration-react';
 
 export const App: React.FunctionComponent = () => {
 
-  const [isLoading, setIsLoading] = React.useState(true);
-
-  const delayState = () => {
-    setTimeout(() => {
-      setIsLoading(false);
-    }, 2000);
-  };
-
-  delayState();
-
   return (
       <Router>
-        <div style={{position: 'relative'}}>
-          { isLoading && <LoadingPage appName="Syndesis"/>}
-          <Page 
-            isManagedSidebar={true}
-            header={<AppHeader />}
-            className="app-page"
-          >
-            <Route path='/' exact={true} component={Pages.Dashboard}/>
-            <Route path='/dashboard' exact={true} component={Pages.Dashboard}/>
-            <Route path='/create-api' exact={true} component={Pages.CreateApi}/>
-            <Route path='/import-api' exact={true} component={Pages.ImportApi}/>
-          </Page>
-        </div>
+      <Page 
+        isManagedSidebar={true}
+        header={<AppHeader />}
+        className="app-page"
+      >
+        <Route path='/' exact={true} component={Pages.Dashboard}/>
+        <Route path='/dashboard' exact={true} component={Pages.Dashboard}/>
+        <Route path='/create-api' exact={true} component={Pages.CreateApi}/>
+        <Route path='/import-api' exact={true} component={Pages.ImportApi}/>
+      </Page>
       </Router>
   );
 }

--- a/packages/studio/src/app/app.tsx
+++ b/packages/studio/src/app/app.tsx
@@ -4,21 +4,35 @@ import AppHeader from "./appHeader";
 import {BrowserRouter as Router, Route} from 'react-router-dom';
 import * as Pages from './pages';
 import './app.css';
+import { LoadingPage } from '@rh-uxd/integration-react';
 
 export const App: React.FunctionComponent = () => {
 
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  const delayState = () => {
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 2000);
+  };
+
+  delayState();
+
   return (
       <Router>
-      <Page 
-        isManagedSidebar={true}
-        header={<AppHeader />}
-        className="app-page"
-      >
-        <Route path='/' exact={true} component={Pages.Dashboard}/>
-        <Route path='/dashboard' exact={true} component={Pages.Dashboard}/>
-        <Route path='/create-api' exact={true} component={Pages.CreateApi}/>
-        <Route path='/import-api' exact={true} component={Pages.ImportApi}/>
-      </Page>
+        <div style={{position: 'relative'}}>
+          { isLoading && <LoadingPage appName="Syndesis"/>}
+          <Page 
+            isManagedSidebar={true}
+            header={<AppHeader />}
+            className="app-page"
+          >
+            <Route path='/' exact={true} component={Pages.Dashboard}/>
+            <Route path='/dashboard' exact={true} component={Pages.Dashboard}/>
+            <Route path='/create-api' exact={true} component={Pages.CreateApi}/>
+            <Route path='/import-api' exact={true} component={Pages.ImportApi}/>
+          </Page>
+        </div>
       </Router>
   );
 }

--- a/packages/studio/webpack.common.js
+++ b/packages/studio/webpack.common.js
@@ -93,8 +93,12 @@ module.exports = {
           path.resolve(__dirname, 'src'),
           path.resolve(__dirname, 'node_modules/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/patternfly'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/patternfly/assets'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/assets/images'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css/assets/images')
+          path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css/assets/images'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-core/dist/styles/assets/images'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-styles/css/assets/images')
         ],
         use: [
           {

--- a/packages/studio/webpack.dev.js
+++ b/packages/studio/webpack.dev.js
@@ -29,7 +29,14 @@ module.exports = merge(common, {
           path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly')
+          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
+          path.resolve(__dirname, 'node_modules/rh-uxd'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/rh-uxd'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/patternfly'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-core/dist/styles/base.css'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-styles/css'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/dist/esm/@patternfly/patternfly'),
         ],
         use: ["style-loader", "css-loader"]
       }

--- a/packages/studio/webpack.prod.js
+++ b/packages/studio/webpack.prod.js
@@ -28,7 +28,14 @@ module.exports = merge(common, {
           path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css')
+          path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
+          path.resolve(__dirname, 'node_modules/rh-uxd'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/rh-uxd'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/patternfly'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-core/dist/styles/base.css'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-styles/css'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
+          path.resolve(__dirname, 'node_modules/@rh-uxd/integration-react/dist/esm/@patternfly/patternfly'),
         ],
         use: [MiniCssExtractPlugin.loader, 'css-loader']
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,6 +1225,19 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@patternfly/react-core@3.131.4":
+  version "3.131.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.131.4.tgz#05119e15b45f8ecb3b17f756674211ad710d1105"
+  integrity sha512-hiVyIHE7t9fKPBOJC2WkYF/nJK3CTiW2UIF4tDQSp+lTXKTHpociXs2IPtrF3or5HZ4tnEK9idS6Y683m3/zIw==
+  dependencies:
+    "@patternfly/react-icons" "^3.14.34"
+    "@patternfly/react-styles" "^3.6.21"
+    "@patternfly/react-tokens" "^2.7.20"
+    emotion "^9.2.9"
+    exenv "^1.2.2"
+    focus-trap-react "^4.0.1"
+    tippy.js "5.1.2"
+
 "@patternfly/react-core@^3.146.0":
   version "3.146.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.146.0.tgz#81f06d6f0e0c122e93e303aa469befed47a767ee"
@@ -1239,10 +1252,24 @@
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
 
+"@patternfly/react-icons@3.14.30":
+  version "3.14.30"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.14.30.tgz#86ee33f47cac6cab0b4ee39a29ab782f9dde6491"
+  integrity sha512-HGtdsht66XKExZ4ew5ZWMXEvDAxQwQxW6sjX8h1diya1VDPpeKU6S1jclDPciSForsNMtfsXoku/jE2N3rUCwg==
+  dependencies:
+    "@fortawesome/free-brands-svg-icons" "^5.8.1"
+
 "@patternfly/react-icons@^3.10.6":
   version "3.14.39"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.14.39.tgz#38e43781ff2c4550814208c68a68681b807270aa"
   integrity sha512-/1hhKEFRtvBYNa8BFRurqHdlUYYzdovmllwtEWcxye5lffDC1Ghco1NGQzjm0FtzkxX1hPFvw04HRR2jBBG8xQ==
+  dependencies:
+    "@fortawesome/free-brands-svg-icons" "^5.8.1"
+
+"@patternfly/react-icons@^3.14.34":
+  version "3.15.17"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.15.17.tgz#97a71fd6469a3f6c08dc46575a340b82cfc7e1db"
+  integrity sha512-Q0JAlxEvSAl5kcMSUMItLiKi9fweO941g5+lS45t3o/Rv4Eg91Ig7AyK1YWw6m1ah+/eHslLfox0Uqw7m7usLg==
   dependencies:
     "@fortawesome/free-brands-svg-icons" "^5.8.1"
 
@@ -1252,6 +1279,17 @@
   integrity sha512-uEzKC9NwpZamCW00mZIxZ5AslFPXVZ+4ThBUOTYSliZUS1DwOKe0549qrAP1vCpz9vCeTR4jyOXBe/kS9IoXpg==
   dependencies:
     "@fortawesome/free-brands-svg-icons" "^5.8.1"
+
+"@patternfly/react-styles@^3.6.21":
+  version "3.7.14"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.7.14.tgz#66a3b6c1cca34d37112485fc0492b12d71a4379e"
+  integrity sha512-NVwbPP9JroulfQgj0LOLWKP4DumArW8RrP1FB1lLOCuw13KkuAcFbLN9MSF8ZBwJ8syxGEdux5mDC3jPjsrQiw==
+  dependencies:
+    camel-case "^3.0.0"
+    css "^2.2.3"
+    cssstyle "^0.3.1"
+    emotion "^9.2.9"
+    emotion-server "^9.2.9"
 
 "@patternfly/react-styles@^3.7.8":
   version "3.7.8"
@@ -1264,10 +1302,33 @@
     emotion "^9.2.9"
     emotion-server "^9.2.9"
 
+"@patternfly/react-tokens@^2.7.20":
+  version "2.8.14"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.8.14.tgz#30b8bd90763fd2a443a875dee4d1d948928f32a1"
+  integrity sha512-pha0XyZ3ZiXuQoKstuFsiEHARFQKUFsS6WxVuRSEyNbGTToRNJkKR9cW5swzHgXK6Fuw5EA2XFHLuu8osj52KA==
+
 "@patternfly/react-tokens@^2.8.8":
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.8.8.tgz#25edde60501708b8fe821f69ab1f284ac1b81814"
   integrity sha512-W3Kx2zlbfFtcjL9mYpjWNU9RfNrFpfXI6zC8qQTuaDwhV3IHCWt5HCkcf9oIW2aCtEjC0EkI67Wbz0BcmdYGJA==
+
+"@rh-uxd/integration-core@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rh-uxd/integration-core/-/integration-core-1.0.3.tgz#a838b477e2eac66ad9c9227a10fc0f46d10e159b"
+  integrity sha512-Qd2oD8/ydcW14+h5Dnx47T4deh03aqV0TdYL0BKcN6VTPSnOfkHEVVVph3aE1yeb1jRwPMAZXuzhMP5dfzDBtQ==
+  dependencies:
+    axios "0.19.2"
+
+"@rh-uxd/integration-react@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rh-uxd/integration-react/-/integration-react-1.0.3.tgz#57521a85cdd89ae9c74202aa60f71bef5bfd6120"
+  integrity sha512-Z6eGlH4Wnk2bIZUklwT8k6i6cHUFfr94yZdHTi11rxlWtRnz4NkoaE2maDq4y4bwiZobhfV0iQR3T7a8T2USaQ==
+  dependencies:
+    "@patternfly/react-core" "3.131.4"
+    "@patternfly/react-icons" "3.14.30"
+    "@rh-uxd/integration-core" "1.0.3"
+    react "16.13.1"
+    react-dom "16.13.1"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -2198,7 +2259,7 @@ axe-core@^3.3.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.1.tgz#e42623918bb85b5ef674633852cb9029db0309c5"
   integrity sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw==
 
-axios@^0.19.2:
+axios@0.19.2, axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
@@ -9142,7 +9203,7 @@ react-axe@^3.1.0:
     axe-core "^3.3.2"
     requestidlecallback "^0.3.0"
 
-react-dom@^16.13.1:
+react-dom@16.13.1, react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -9221,7 +9282,7 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.18.0"
 
-react@^16.13.1:
+react@16.13.1, react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,21 +1312,21 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.8.8.tgz#25edde60501708b8fe821f69ab1f284ac1b81814"
   integrity sha512-W3Kx2zlbfFtcjL9mYpjWNU9RfNrFpfXI6zC8qQTuaDwhV3IHCWt5HCkcf9oIW2aCtEjC0EkI67Wbz0BcmdYGJA==
 
-"@rh-uxd/integration-core@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rh-uxd/integration-core/-/integration-core-1.0.3.tgz#a838b477e2eac66ad9c9227a10fc0f46d10e159b"
-  integrity sha512-Qd2oD8/ydcW14+h5Dnx47T4deh03aqV0TdYL0BKcN6VTPSnOfkHEVVVph3aE1yeb1jRwPMAZXuzhMP5dfzDBtQ==
+"@rh-uxd/integration-core@1.0.4", "@rh-uxd/integration-core@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@rh-uxd/integration-core/-/integration-core-1.0.4.tgz#374439ae6beb811d176bf33a84de2a6fb5349562"
+  integrity sha512-XTKVk6cqKwcz0am3c+5oJ0DpsRhbeZG7zauJPY0tzlHdbVVp+N5AQ57eu1gwrsUCfcButry+awD6spL2FPTAeA==
   dependencies:
     axios "0.19.2"
 
-"@rh-uxd/integration-react@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rh-uxd/integration-react/-/integration-react-1.0.3.tgz#57521a85cdd89ae9c74202aa60f71bef5bfd6120"
-  integrity sha512-Z6eGlH4Wnk2bIZUklwT8k6i6cHUFfr94yZdHTi11rxlWtRnz4NkoaE2maDq4y4bwiZobhfV0iQR3T7a8T2USaQ==
+"@rh-uxd/integration-react@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@rh-uxd/integration-react/-/integration-react-1.0.4.tgz#d5ec345bb55d81d25d3c0e323ae36dbe2c344d2c"
+  integrity sha512-w+LJIGVnr0UudkCI+vrbeG46k5BXREHt83Y5RsO3F8+2III+MvmVwwgDcidvCuNcw3MU8l/lIRBScoqJ56h8XA==
   dependencies:
     "@patternfly/react-core" "3.131.4"
     "@patternfly/react-icons" "3.14.30"
-    "@rh-uxd/integration-core" "1.0.3"
+    "@rh-uxd/integration-core" "1.0.4"
     react "16.13.1"
     react-dom "16.13.1"
 


### PR DESCRIPTION
Closes #42 and fixes builds for the listed CI pipelines. The `rh-uxd` package is now generated in `node_modules` for `studio`, and is no longer hoisted into the project root.